### PR TITLE
Fix potential crash when a UI dialog is closed

### DIFF
--- a/script/event-handlers.lua
+++ b/script/event-handlers.lua
@@ -113,7 +113,7 @@ local function onLuaShortcut(event)
 end
 
 local function onGuiClosed(event)
-    if string.find(event.element.name, "fi_frame_main_dialog") then 
+    if event.element and string.find(event.element.name, "fi_frame_main_dialog") then 
         local player = game.get_player(event.player_index)
         fiMainFrame.toggle(player)
     end


### PR DESCRIPTION
Fixes a potential crash when handling a UI close event where `event.element` is not set.