### PR TITLE
Changed enrollment of solid and fluid fuel to only happen if there is…

### DIFF
--- a/script/entity-tracker.lua
+++ b/script/entity-tracker.lua
@@ -49,10 +49,12 @@ local function updateConsumersAndProducers(entity)
 
     local recipe = recipe_functions.getRecipe(entity)
     -- consumption
-    if recipe then input_output_calculator.enrolConsumedRecipeIngredients(entity, recipe) end
+    if recipe then 
+        input_output_calculator.enrolConsumedRecipeIngredients(entity, recipe) 
+        input_output_calculator.enrolConsumedSolidFuel(entity, recipe)
+        input_output_calculator.enrolConsumedFluidFuel(entity, recipe)
+        end
     if entity.type == "mining-drill" then input_output_calculator.enrolConsumedMiningFluid(entity) end
-    input_output_calculator.enrolConsumedSolidFuel(entity, recipe)
-    input_output_calculator.enrolConsumedFluidFuel(entity, recipe)
 
     -- production
     if entity.type == "mining-drill" then input_output_calculator.enrolProducedMiningOutputs(entity) end


### PR DESCRIPTION
… a selected recipe for the entity.

This fixes a crash bug when entities are placed but do not have a recipe selected.